### PR TITLE
Add TCP and Port management:

### DIFF
--- a/example/Client.hs
+++ b/example/Client.hs
@@ -7,7 +7,7 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
-
+{-# LANGUAGE OverloadedStrings #-}
 import System.Environment
 import Network.DNS.API.Client
 import Network.DNS.API.Types
@@ -21,6 +21,9 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BS
 
+uniqueNonce :: ByteString
+uniqueNonce = "nonce"
+
 main :: IO ()
 main = do
   args <- getArgs
@@ -30,12 +33,12 @@ main = do
       let req = Request
                   { domain = BS.pack d
                   , cmd = Command (BS.pack c) (BS.pack p)
-                  , nonce = B.pack [1..12]
+                  , nonce = uniqueNonce
                   }
-      rs <- makeResolvSeedSafe (Just $ BS.pack d) Nothing Nothing
+      rs <- makeResolvSeedSafe (Just $ BS.pack d) (Just $ fromIntegral 8053) Nothing Nothing
       rep <- runExceptT $ sendQueryDefaultTo rs req :: IO (Either String (Response ByteString))
       case rep of
-        Left err -> error  err
-        Right re -> do print $ "nonce == signature ? " ++ (show $ (signature re) == (B.pack [1..12]))
+        Left err -> error $ "exmaple.Client: " ++ err
+        Right re -> do print $ "nonce == signature ? " ++ (show $ (signature re) == uniqueNonce)
                        print re
     _ -> putStrLn $ "usage: " ++ name ++ " <domain> <echo|db> <param>"

--- a/example/Server.hs
+++ b/example/Server.hs
@@ -15,6 +15,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString      as S
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Maybe
 
 import Network.DNS.API.Server
 import qualified Network.DNS.API.Types as API
@@ -31,7 +32,8 @@ main = do
   args <- getArgs
   name <- getProgName
   case args of
-    [dom] -> defaultServer (serverConf dom)
+    [dom] -> do sl <- getDefaultSockets (Just "8053") >>= return.catMaybes
+                defaultServer (serverConf dom) sl
     _     -> putStrLn $ "usage: " ++ name ++ " <Database FQDN>"
   where
     serverConf :: String -> ServerConf ByteString
@@ -58,8 +60,8 @@ exampleDB =
 
 -- | example of query manager
 -- handle two commands:
--- * echo: return $ Just $ "nonce" ++ ';' ++ "param"
--- * db  : return $ the result of a lookup in the database
+-- * echo: the param
+-- * db  : return the DB
 --
 -- This actual example just ignore who sent it.
 queryDummy :: ByteString -> a -> ByteString -> IO (Maybe (API.Response ByteString))


### PR DESCRIPTION
You can now use this library to start a DNS API server on a different
port than 53.

Also allow TCP Connection for simple requests. (will soon implement some
machinery to use complexe request and eventually a way to have a state
machine) in the case of TCP connections.
